### PR TITLE
Update website list hostname filter to follow latest rest

### DIFF
--- a/Models/WebsiteList.ts
+++ b/Models/WebsiteList.ts
@@ -6,7 +6,7 @@ export const hostnameFilter : (website: Readonly<Website>, host: string, languag
     const matchHost = (website.hosts ? website.hosts.filter(h => {
         if (matchWildcard && h.name === '*') return true;
         if (h.name !== host) return false;
-        return language && h.language ? language === h.language : true;
+        return language && h.language ? language === h.language.name : true;
     }) : []).length > 0;
     return matchHost;
 }


### PR DESCRIPTION
Update language comparison according to latest Content Delivery REST setup. Language is not a string but an object with name and displayName properties. So comparison needs to be fixed here or else it is always false